### PR TITLE
chore: general clean-up + add prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "tab": 2
+}

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,12 +1,19 @@
 #!/usr/bin/env node
-const child_process = require('child_process')
+const child_process = require('child_process');
 
-let args = process.argv
-child_process.spawn('create-next-app',
-    [...(args[2] ? [args[2]] :[]), // skip the first argument if undefined
-    '--example=https://github.com/Developer-DAO/create-dao/tree/main/template'],
-{
+let args = process.argv;
+child_process.spawn(
+  'create-next-app',
+  [
+    ...(args[2] ? [args[2]] : []), // skip the first argument if undefined
+    '--example=https://github.com/Developer-DAO/create-dao/tree/main/template',
+  ],
+  {
     cwd: process.cwd(),
     detached: false,
-    stdio: "inherit"
-})
+    stdio: 'inherit',
+  }
+);
+console.log(
+  '<TEMP> Before running that, make sure you run and deploy your contract locally. `npm run chain`, then in another terminal run `npm run deploy:local`'
+);

--- a/template/contracts/NFT.sol
+++ b/template/contracts/NFT.sol
@@ -18,11 +18,9 @@ contract NFT is ERC721Enumerable, Ownable {
     string public notRevealedUri;
 
     constructor(
-        string memory _name,
-        string memory _symbol,
         string memory _initBaseURI,
         string memory _initNotRevealedUri
-    ) ERC721(_name, _symbol) {
+    ) ERC721("NFT_NAME", "NFT_SYMBOL") {
         setBaseURI(_initBaseURI);
         setNotRevealedURI(_initNotRevealedUri);
     }

--- a/template/hardhat.config.js
+++ b/template/hardhat.config.js
@@ -1,8 +1,8 @@
-require("@nomiclabs/hardhat-waffle");
+require('@nomiclabs/hardhat-waffle');
 
 // This is a sample Hardhat task. To learn how to create your own go to
 // https://hardhat.org/guides/create-task.html
-task("accounts", "Prints the list of accounts", async (taskArgs, hre) => {
+task('accounts', 'Prints the list of accounts', async (taskArgs, hre) => {
   const accounts = await hre.ethers.getSigners();
 
   for (const account of accounts) {
@@ -17,13 +17,21 @@ task("accounts", "Prints the list of accounts", async (taskArgs, hre) => {
  * @type import('hardhat/config').HardhatUserConfig
  */
 module.exports = {
-  solidity: "0.8.9",
+  solidity: '0.8.9',
   paths: {
     artifacts: './src/artifacts',
   },
   networks: {
     hardhat: {
-      chainId: 1337
-    }
-  }
+      chainId: 31337,
+    },
+    rinkeby: {
+      chainId: 4,
+      url: 'https://rinkeby.infura.io/v3/YOUR_PROJECT_ID',
+    },
+    mainnet: {
+      chainId: 1,
+      url: 'https://mainnet.infura.io/v3/YOUR_PROJECT_ID',
+    },
+  },
 };

--- a/template/package.json
+++ b/template/package.json
@@ -5,7 +5,10 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "chain": "npx hardhat node",
+    "compile": "npx hardhat compile",
+    "deploy": "npm run compile && npx hardhat run scripts/deploy.js --network localhost"
   },
   "dependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.2",

--- a/template/pages/_app.js
+++ b/template/pages/_app.js
@@ -1,7 +1,7 @@
-import '../styles/globals.css'
+import '../styles/globals.css';
 
 function MyApp({ Component, pageProps }) {
-  return <Component {...pageProps} />
+  return <Component {...pageProps} />;
 }
 
-export default MyApp
+export default MyApp;

--- a/template/pages/api/hello.js
+++ b/template/pages/api/hello.js
@@ -1,5 +1,0 @@
-// Next.js API route support: https://nextjs.org/docs/api-routes/introduction
-
-export default function handler(req, res) {
-  res.status(200).json({ name: 'John Doe' })
-}

--- a/template/pages/index.js
+++ b/template/pages/index.js
@@ -1,18 +1,16 @@
-import Head from 'next/head'
-import Image from 'next/image'
-import styles from '../styles/Home.module.css'
+import Head from 'next/head';
+import Image from 'next/image';
+import styles from '../styles/Home.module.css';
 import { useState } from 'react';
-import { ethers } from 'ethers'
-import Greeter from '../src/artifacts/contracts/Greeter.sol/Greeter.json'
+import { ethers } from 'ethers';
+import Greeter from '../src/artifacts/contracts/Greeter.sol/Greeter.json';
 
-// Update with the contract address logged out to the CLI when it was deployed 
-const greeterAddress = "your-contract-address"
+// Update with the contract address logged out to the CLI when it was deployed
+const greeterAddress = '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0';
 
 export default function Home() {
-
-
   // store greeting in local state
-  const [greeting, setGreetingValue] = useState()
+  const [greeting, setGreetingValue] = useState();
 
   // request access to the user's MetaMask account
   async function requestAccount() {
@@ -22,39 +20,45 @@ export default function Home() {
   // call the smart contract, read the current greeting value
   async function fetchGreeting() {
     if (typeof window.ethereum !== 'undefined') {
-      const provider = new ethers.providers.Web3Provider(window.ethereum)
-      const contract = new ethers.Contract(greeterAddress, Greeter.abi, provider)
+      const provider = new ethers.providers.Web3Provider(window.ethereum);
+      const contract = new ethers.Contract(
+        greeterAddress,
+        Greeter.abi,
+        provider
+      );
       try {
-        const data = await contract.greet()
-        console.log('data: ', data)
+        const data = await contract.greet();
+        console.log('data: ', data);
       } catch (err) {
-        console.log("Error: ", err)
+        console.log('Error: ', err);
       }
-    }    
+    }
   }
 
   // call the smart contract, send an update
   async function setGreeting() {
-    if (!greeting) return
+    if (!greeting) return;
     if (typeof window.ethereum !== 'undefined') {
-      await requestAccount()
+      await requestAccount();
       const provider = new ethers.providers.Web3Provider(window.ethereum);
-      const signer = provider.getSigner()
-      const contract = new ethers.Contract(greeterAddress, Greeter.abi, signer)
-      const transaction = await contract.setGreeting(greeting)
-      await transaction.wait()
-      fetchGreeting()
+      const signer = provider.getSigner();
+      const contract = new ethers.Contract(greeterAddress, Greeter.abi, signer);
+      const transaction = await contract.setGreeting(greeting);
+      await transaction.wait();
+      fetchGreeting();
     }
   }
 
   return (
-    <div className="App">
-      <header className="App-header">
+    <div className='App'>
+      <header className='App-header'>
         <button onClick={fetchGreeting}>Fetch Greeting</button>
         <button onClick={setGreeting}>Set Greeting</button>
-        <input onChange={e => setGreetingValue(e.target.value)} placeholder="Set greeting" />
+        <input
+          onChange={(e) => setGreetingValue(e.target.value)}
+          placeholder='Set greeting'
+        />
       </header>
     </div>
   );
-
 }

--- a/template/scripts/deploy.js
+++ b/template/scripts/deploy.js
@@ -20,7 +20,7 @@ async function main() {
   console.log('Token deployed to:', token.address);
 
   const NFT = await hre.ethers.getContractFactory('NFT');
-  const nft = await NFT.deploy();
+  const nft = await NFT.deploy('test', 'test');
   await nft.deployed();
   console.log('NFT deployed to:', nft.address);
 


### PR DESCRIPTION
- Added a temporary instruction for when the script finishes running.
- Added prettier & formatted files.
- Added rinkeby and mainnet to hardhat config.
- Updated hardhat local chain ID.
- Added some helper scripts in the template's package.json.
- Renamed the deploy script.
- Slightly refactored the NFT contract to not require a name and a symbol as an input. This is so that the user doesn't have to go to the deploy script to pass in the name & symbol. They can just pass it in the `.sol` file instead.
- Removed unused Next.js api routes.