### PR TITLE
Add surge deployment support and do some clean-up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,5 @@ yarn.lock
 
 # DynamoDB Local files
 .dynamodb/
+
+out/

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "deploy:mainnet": "yarn workspace @create-dao/next-app deploy:mainnet",
     "update-version": "lerna version --force-publish --no-private",
     "publish-latest": "lerna publish from-package",
-    "create-dao": "node ./packages/create-dao/index.js"
+    "create-dao": "node ./packages/create-dao/index.js",
+    "surge": "yarn workspace @create-dao/next-app surge"
   },
   "devDependencies": {
     "lerna": "^4.0.0"

--- a/packages/create-dao/create-app.js
+++ b/packages/create-dao/create-app.js
@@ -60,6 +60,8 @@ const init = async ({ appPath, useNpm, typescript }) => {
       deploy:
         'npm run compile && npx hardhat run scripts/deploy.js --network localhost',
       test: 'npx hardhat coverage',
+      export: 'next export',
+      surge: 'cp out/index.html out/200.html && surge ./out',
     },
   };
   /**
@@ -86,7 +88,7 @@ const init = async ({ appPath, useNpm, typescript }) => {
     '@emotion/styled@^11',
     'framer-motion@^4',
     'react-icons',
-    '@web3-ui/core'
+    '@web3-ui/core',
   ];
   /**
    * Default devDependencies.

--- a/packages/create-dao/templates/default/package.json
+++ b/packages/create-dao/templates/default/package.json
@@ -11,7 +11,9 @@
     "compile": "npx hardhat compile",
     "deploy": "npm run compile && npx hardhat run scripts/deploy.js --network localhost",
     "deploy:rinkeby": "npm run compile && npx hardhat run scripts/deploy.js --network rinkeby",
-    "deploy:mainnet": "npm run compile && npx hardhat run scripts/deploy.js --network mainnet"
+    "deploy:mainnet": "npm run compile && npx hardhat run scripts/deploy.js --network mainnet",
+    "export": "next export",
+    "surge": "cp out/index.html out/200.html && surge ./out"
   },
   "dependencies": {
     "@chakra-ui/react": "1.7.2",

--- a/packages/create-dao/templates/default/pages/mint.js
+++ b/packages/create-dao/templates/default/pages/mint.js
@@ -35,7 +35,6 @@ export default function Mint() {
       await nftContract.totalSupply(),
       await nftContract.cost(),
     ]);
-    console.log({ maxSupply, totalSupply: totalSupply.toString(), mintPrice });
     setMaxSupply(maxSupply.toString());
     setTotalSupply(totalSupply.toString());
     setMintPrice(ethers.utils.formatEther(mintPrice.toString()));
@@ -65,12 +64,15 @@ export default function Mint() {
             onClick={async () => {
               try {
                 await execMint();
-                toast({
-                  title: 'Successfully minted your NFT!',
-                  status: 'success',
-                });
+                if (!mintError) {
+                  toast({
+                    title: 'Successfully minted your NFT!',
+                    status: 'success',
+                  });
+                } else {
+                  throw new Error(mintError);
+                }
               } catch (error) {
-                console.error(error);
                 toast({
                   title: 'Failed to mint your NFT',
                   description: error.message,


### PR DESCRIPTION
- Added `surge` command to package.json that lets you deploy your UI to surge instantly 🥳 
- Identified a logical error where a success toast was being shown even when there was an error during mint. 
- Cleaned up some console.logs